### PR TITLE
Buzz version constraint is now less strict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "kriswallsmith/buzz": "0.7",
+        "kriswallsmith/buzz": ">=0.7,<=0.10",
         "php": ">=5.3.0"
     },
     "autoload": {


### PR DESCRIPTION
The Buzz constraint for version 0.7 is too strict. It clashes with other libraries or bundles using Buzz with a higher version constraint. 
